### PR TITLE
Add `--version` option feature

### DIFF
--- a/djlsp/cli.py
+++ b/djlsp/cli.py
@@ -1,11 +1,17 @@
 import argparse
 import logging
 
+from djlsp import __version__
 from djlsp.server import server
 
 
 def main():
     parser = argparse.ArgumentParser(description="Django template LSP")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     parser.add_argument("--enable-log", action="store_true")
 
     args = parser.parse_args()


### PR DESCRIPTION
## Description

Hi. Thank you for creating a wonderful language server.

By the way, I have added a `--version` option to the `djlsp` (`django-template-lsp`) command.

## Screen shot

<img width="727" alt="djlsp-add-version-option" src="https://github.com/fourdigits/django-template-lsp/assets/188642/a1439f08-3ad7-461d-ab84-1e4013c3dc53">
