### PR TITLE
fix(docs): fix Neovim config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Project settings `.helix/languages.toml`:
 django_settings_modules="<your.settings.module>"
 ```
 
-### NeoVim
+### Neovim
 
 In your lspconfig add the following
 
 ```lua
 require'lspconfig'.djlsp.setup{
     cmd = { "<path-to-djlsp>" },
-    settings = {
+    init_options = {
         djlsp = {
             django_settings_module = "<your.settings.module>"
             docker_compose_file = "docker-compose.yml",


### PR DESCRIPTION
Although I don't primarily use Neovim's built-in LSP feature, I found some typo in the README and have corrected them.

- `NeoVim` -> `Neovim`
- `settings` -> `init_options`
  - `initializationOption` is `init_options`.
  - REF: <https://github.com/neovim/neovim/blob/20a7eebec086129e605041d32916f36df50890de/runtime/doc/lsp.txt#L1138-L1139>
