### PR TITLE
Implement Types to Diagnostic Completion Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Locally install the package
 make develop
 ```
 
-Point neovim's `djlsp` to locally installed copy
+Point neovim's `djlsp` to the locally installed copy
 
 ``` lua
 require("lspconfig").djlsp.setup({
@@ -144,4 +144,3 @@ require("lspconfig").djlsp.setup({
         root_dir = require("lspconfig.util").root_pattern("manage.py", ".git"),
 })
 ```
-

--- a/README.md
+++ b/README.md
@@ -127,3 +127,21 @@ To start the Helix editor with the environment activated and the correct workspa
 ```bash
 make helix
 ```
+
+### neovim
+
+Locally install the package
+
+``` sh
+make develop
+```
+
+Point neovim's `djlsp` to locally installed copy
+
+``` lua
+require("lspconfig").djlsp.setup({
+        cmd = { "/path/to/django-template-lsp/.venv/bin/djlsp" },
+        root_dir = require("lspconfig.util").root_pattern("manage.py", ".git"),
+})
+```
+

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -142,7 +142,7 @@ class TemplateParser:
             "path": CompletionItemKind.File,
             "property": CompletionItemKind.Property,
             "statement": CompletionItemKind.Variable,
-            "function": CompletionItemKind.Method,
+            "function": CompletionItemKind.Function,
         }
         return kind_mapping.get(comp_type, CompletionItemKind.Field)
 

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -135,7 +135,6 @@ class TemplateParser:
         # https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
         kind_mapping = {
             "class": CompletionItemKind.Class,
-            "function": CompletionItemKind.Function,
             "instance": CompletionItemKind.Variable,
             "keyword": CompletionItemKind.Keyword,
             "module": CompletionItemKind.Module,
@@ -143,6 +142,7 @@ class TemplateParser:
             "path": CompletionItemKind.File,
             "property": CompletionItemKind.Property,
             "statement": CompletionItemKind.Variable,
+            "function": CompletionItemKind.Method,
         }
         return kind_mapping.get(comp_type, CompletionItemKind.Field)
 

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -130,7 +130,7 @@ class TemplateParser:
 
         return jedi.Script(code="\n".join(script_lines), project=self.jedi_project)
 
-    def _jedi_type_to_completion_kind(self, comp_type: str):
+    def _jedi_type_to_completion_kind(self, comp_type: str) -> CompletionItemKind:
         """Map Jedi completion types to LSP CompletionItemKind."""
         # https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
         kind_mapping = {

--- a/tests/test_completion_kinds.py
+++ b/tests/test_completion_kinds.py
@@ -3,114 +3,51 @@ Test the type of completion feedback returned by diagnostic server, such as
 properties, methods and keywords
 """
 
+import pytest
 from lsprotocol.types import CompletionItemKind
 
 from tests.test_parser import create_parser
 
 
-def test_load_completions_use_module_kind():
-    parser = create_parser("{% load w")
-    completions = parser.completions(0, 8)
-    assert completions[0].kind == CompletionItemKind.Module
+@pytest.mark.parametrize(
+    "content,line_number,expected_kind",
+    [
+        ("{# type blog: django", 0, CompletionItemKind.Module),
+        ("{% load website %}\n{{ value|up", 1, CompletionItemKind.Function),
+        ("{% url 'web", 0, CompletionItemKind.Reference),
+        ("{% static 'js", 0, CompletionItemKind.File),
+        ("{{ bl", 0, CompletionItemKind.Variable),
+        ("{# type news: str #}\n{{ news|cap", 1, CompletionItemKind.Function),
+        ("{% extends 'ba", 0, CompletionItemKind.File),
+        ("{% block header %}\n{% endblock ", 1, CompletionItemKind.Property),
+        ("{% load w", 0, CompletionItemKind.Module),
+        ("{% extends 'base.html' %}\n{% block h", 1, CompletionItemKind.Property),
+        (
+            "{# type customer: django.db.models.Model #}\n{{ customer.sav",
+            1,
+            CompletionItemKind.Method,
+        ),
+        (
+            "{# type customer: django.db.models.Model #}\n{{ customer.objec",
+            1,
+            CompletionItemKind.Module,
+        ),
+        (
+            "{# type customer: django.db.models.Model #}\n{{ customer.pk",
+            1,
+            CompletionItemKind.Variable,
+        ),
+    ],
+)
+def test_completion_suggestion_kind(
+    content: str, line_number: int, expected_kind: CompletionItemKind
+):
+    parser = create_parser(content)
 
+    lines = content.split("\n")
+    target_line = lines[line_number]
+    eol = len(target_line)
 
-def test_block_completions_use_property_kind():
-    parser = create_parser("{% extends 'base.html' %}\n{% block h")
-    completions = parser.completions(1, 9)
-    assert completions[0].kind == CompletionItemKind.Property
-
-
-def test_endblock_completions_use_property_kind():
-    parser = create_parser("{% block header %}\n{% endblock ")
-    completions = parser.completions(1, 12)
-    assert completions[0].kind == CompletionItemKind.Property
-
-
-def test_static_completions_use_file_kind():
-    parser = create_parser("{% static 'js")
-    completions = parser.completions(0, 12)
-    assert completions[0].kind == CompletionItemKind.File
-
-
-def test_url_completions_use_reference_kind():
-    parser = create_parser("{% url 'web")
-    completions = parser.completions(0, 11)
-    assert completions[0].kind == CompletionItemKind.Reference
-
-
-def test_template_completions_use_file_kind():
-    parser = create_parser("{% extends 'ba")
-    completions = parser.completions(0, 12)
-    assert completions[0].kind == CompletionItemKind.File
-
-
-def test_tag_completions_use_keyword_kind():
-    parser = create_parser("{% load website %}\n{% get")
-    completions = parser.completions(1, 5)
-    homepage_tag = [item for item in completions if item.label == "get_homepage"][0]
-    assert homepage_tag.kind == CompletionItemKind.Keyword
-
-
-def test_filter_completions_use_function_kind():
-    parser = create_parser("{% load website %}\n{{ value|cur")
-    completions = parser.completions(1, 12)
-    assert completions[0].kind == CompletionItemKind.Function
-
-
-def test_type_comment_completions_use_class_kind():
-    parser = create_parser("{# type blog: django")
-    completions = parser.completions(0, 18)
-    assert completions[0].kind == CompletionItemKind.Class
-
-
-def test_context_variable_completions_use_variable_kind():
-    parser = create_parser("{{ bl")
-    completions = parser.completions(0, 5)
-    assert completions[0].kind == CompletionItemKind.Variable
-
-
-def test_context_string_method_completions():
-    """Test that string methods have Method kind"""
-    parser = create_parser("{# type news: str #}\n{{ news.")
-    completions = parser.completions(1, 9)
-
-    methods = [
-        item
-        for item in completions
-        if item.label in ("capitalize", "upper", "split", "strip")
-    ]
-
-    for method in methods:
-        assert method.kind == CompletionItemKind.Function
-
-
-def test_context_field_completions():
-    """Test that other attributes are reported as Field"""
-    parser = create_parser("{# type news: dict #}\n{{ news.")
-    completions = parser.completions(1, 9)
-
-    fields = [item for item in completions if item.label in ("items", "keys", "values")]
-
-    for field in fields:
-        assert field.kind != CompletionItemKind.Property
-
-
-def test_django_model_property_completions():
-    """Test that Django model attributes have appropriate kinds."""
-    parser = create_parser("{# type customer: django.db.models.Model #}\n{{ customer.")
-    completions = parser.completions(1, 12)
-
-    model_attributes = [
-        item
-        for item in completions
-        if item.label
-        in ("id", "pk", "objects", "save", "delete", "first_name", "last_name")
-    ]
-
-    for attr in model_attributes:
-        if attr.label in ("first_name", "last_name", "id", "pk"):
-            assert attr.kind == CompletionItemKind.Field
-        elif attr.label in ("save", "delete"):
-            assert attr.kind == CompletionItemKind.Method
-        elif attr.label == "objects":
-            assert attr.kind == CompletionItemKind.Field
+    completions = parser.completions(line_number, eol)
+    assert completions
+    assert completions[0].kind == expected_kind

--- a/tests/test_completion_kinds.py
+++ b/tests/test_completion_kinds.py
@@ -1,0 +1,116 @@
+"""
+Test the type of completion feedback returned by diagnostic server, such as
+properties, methods and keywords
+"""
+
+from lsprotocol.types import CompletionItemKind
+
+from tests.test_parser import create_parser
+
+
+def test_load_completions_use_module_kind():
+    parser = create_parser("{% load w")
+    completions = parser.completions(0, 8)
+    assert completions[0].kind == CompletionItemKind.Module
+
+
+def test_block_completions_use_property_kind():
+    parser = create_parser("{% extends 'base.html' %}\n{% block h")
+    completions = parser.completions(1, 9)
+    assert completions[0].kind == CompletionItemKind.Property
+
+
+def test_endblock_completions_use_property_kind():
+    parser = create_parser("{% block header %}\n{% endblock ")
+    completions = parser.completions(1, 12)
+    assert completions[0].kind == CompletionItemKind.Property
+
+
+def test_static_completions_use_file_kind():
+    parser = create_parser("{% static 'js")
+    completions = parser.completions(0, 12)
+    assert completions[0].kind == CompletionItemKind.File
+
+
+def test_url_completions_use_reference_kind():
+    parser = create_parser("{% url 'web")
+    completions = parser.completions(0, 11)
+    assert completions[0].kind == CompletionItemKind.Reference
+
+
+def test_template_completions_use_file_kind():
+    parser = create_parser("{% extends 'ba")
+    completions = parser.completions(0, 12)
+    assert completions[0].kind == CompletionItemKind.File
+
+
+def test_tag_completions_use_keyword_kind():
+    parser = create_parser("{% load website %}\n{% get")
+    completions = parser.completions(1, 5)
+    homepage_tag = [item for item in completions if item.label == "get_homepage"][0]
+    assert homepage_tag.kind == CompletionItemKind.Keyword
+
+
+def test_filter_completions_use_function_kind():
+    parser = create_parser("{% load website %}\n{{ value|cur")
+    completions = parser.completions(1, 12)
+    assert completions[0].kind == CompletionItemKind.Function
+
+
+def test_type_comment_completions_use_class_kind():
+    parser = create_parser("{# type blog: django")
+    completions = parser.completions(0, 18)
+    assert completions[0].kind == CompletionItemKind.Class
+
+
+def test_context_variable_completions_use_variable_kind():
+    parser = create_parser("{{ bl")
+    completions = parser.completions(0, 5)
+    assert completions[0].kind == CompletionItemKind.Variable
+
+
+def test_context_string_method_completions():
+    """Test that string methods have Method kind"""
+    parser = create_parser("{# type news: str #}\n{{ news.")
+    completions = parser.completions(1, 9)
+
+    methods = [
+        item
+        for item in completions
+        if item.label in ("capitalize", "upper", "split", "strip")
+    ]
+
+    for method in methods:
+        assert method.kind == CompletionItemKind.Method
+
+
+def test_context_field_completions():
+    """Test that other attributes are reported as Field"""
+    parser = create_parser("{# type news: dict #}\n{{ news.")
+    completions = parser.completions(1, 9)
+
+    fields = [item for item in completions if item.label in ("items", "keys", "values")]
+
+    for field in fields:
+        assert field.kind != CompletionItemKind.Property
+
+
+def test_django_model_property_completions():
+    """Test that Django model attributes have appropriate kinds."""
+    parser = create_parser("{# type customer: django.db.models.Model #}\n{{ customer.")
+    completions = parser.completions(1, 12)
+
+    model_attributes = [
+        item
+        for item in completions
+        if item.label
+        in ("id", "pk", "objects", "save", "delete", "first_name", "last_name")
+    ]
+
+    for attr in model_attributes:
+        if attr.label in ("first_name", "last_name", "id", "pk"):
+            assert attr.kind == CompletionItemKind.Field
+        elif attr.label in ("save", "delete"):
+            assert attr.kind == CompletionItemKind.Method
+        elif attr.label == "objects":
+            assert attr.kind == CompletionItemKind.Field

--- a/tests/test_completion_kinds.py
+++ b/tests/test_completion_kinds.py
@@ -25,7 +25,7 @@ from tests.test_parser import create_parser
         (
             "{# type customer: django.db.models.Model #}\n{{ customer.sav",
             1,
-            CompletionItemKind.Method,
+            CompletionItemKind.Function,
         ),
         (
             "{# type customer: django.db.models.Model #}\n{{ customer.objec",

--- a/tests/test_completion_kinds.py
+++ b/tests/test_completion_kinds.py
@@ -81,7 +81,7 @@ def test_context_string_method_completions():
     ]
 
     for method in methods:
-        assert method.kind == CompletionItemKind.Method
+        assert method.kind == CompletionItemKind.Function
 
 
 def test_context_field_completions():


### PR DESCRIPTION
This change incorporates `CompletionItemKind` to provide feedback via the language server to inform the editor of the `kind` of feedback it is receiving. This information provides a richer user experience as we can now differentiate completion suggestions between types, such as fields and methods.

Prior to this change, everything would have defaulted to `Text` as no `kind` was specified

| Example | Before | After |
|---------|--------|--------|
| **1**   | ![image](https://github.com/user-attachments/assets/8604e0c8-3854-490f-895f-a510a3db1ae5) | ![image](https://github.com/user-attachments/assets/542680d0-57a0-48a1-9063-9edea996ac47) |
| **2**   | ![image](https://github.com/user-attachments/assets/58f7f3d1-9aa8-4928-9980-36e293cec3aa) | ![image](https://github.com/user-attachments/assets/a1acc1c9-5cd0-4028-b504-637b95cf7261) |


```
@enum.unique
class CompletionItemKind(int, enum.Enum):
    """The kind of a completion entry."""

    Text = 1
    Method = 2
    Function = 3
    Constructor = 4
    Field = 5
    Variable = 6
    Class = 7
    Interface = 8
    Module = 9
    Property = 10
    Unit = 11
    Value = 12
    Enum = 13
    Keyword = 14
    Snippet = 15
    Color = 16
    File = 17
    Reference = 18
    Folder = 19
    EnumMember = 20
    Constant = 21
    Struct = 22
    Event = 23
    Operator = 24
    TypeParameter = 25
```