### PR TITLE
Caching collected data if nothing has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Once installed, the Django template LSP server is accessible via the following c
 - `docker_compose_file` (string) default: "docker-compose.yml"
 - `docker_compose_service` (string) default: "django"
 - `django_settings_module` (string) default (auto detected when empty): ""
+- `cache` (boolean/string) default (either true/false or a filepath to the cachefile): false
 
 ## Data Collection Method
 
@@ -144,3 +145,13 @@ require("lspconfig").djlsp.setup({
         root_dir = require("lspconfig.util").root_pattern("manage.py", ".git"),
 })
 ```
+
+If you want to access the log while developing, add the `--enable-log` flag to the cmd.
+The logfile will be written to a file in your current working directory named `djlsp.log`.
+
+``` lua
+require("lspconfig").djlsp.setup({
+        cmd = { "/path/to/django-template-lsp/.venv/bin/djlsp", "--enable-log" },
+})
+```
+

--- a/djlsp/cli.py
+++ b/djlsp/cli.py
@@ -40,6 +40,13 @@ def main():
         action="store_true",
         help="Attempt to collect Django data and display logs.",
     )
+    parser.add_argument(
+        "--cache",
+        nargs="?",
+        const=True,
+        default=False,
+        help="Use cache for Django data collection (optional provide a filepath)"
+    )
 
     args = parser.parse_args()
 
@@ -47,6 +54,7 @@ def main():
         "docker_compose_file": args.docker_compose_file,
         "docker_compose_service": args.docker_compose_service,
         "django_settings_module": args.django_settings_module,
+        "cache": args.cache,
     }
 
     if args.collect:

--- a/djlsp/cli.py
+++ b/djlsp/cli.py
@@ -45,7 +45,7 @@ def main():
         nargs="?",
         const=True,
         default=False,
-        help="Use cache for Django data collection (optional provide a filepath)"
+        help="Use cache for Django data collection (optional provide a filepath)",
     )
 
     args = parser.parse_args()

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -201,7 +201,7 @@ class DjangoTemplateLanguageServer(LanguageServer):
             self.current_file_watcher_globs = self.workspace_index.file_watcher_globs
             self.set_file_watcher_capability()
 
-        if self.cache and not loaded_from_cache:
+        if self.cache and not loaded_from_cache and django_data:
             self._store_django_data_to_cache(django_data)
 
     def _get_django_data_from_cache(self):

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -244,6 +244,7 @@ class DjangoTemplateLanguageServer(LanguageServer):
             for p in django_data["file_watcher_globs"]
             for f in glob.glob(p, recursive=True)
         )
+        files.add(DJANGO_COLLECTOR_SCRIPT_PATH)
 
         h = hashlib.md5()
         for f in sorted(files):

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -284,8 +284,8 @@ class DjangoTemplateLanguageServer(LanguageServer):
 
         try:
             return json.loads(subprocess.check_output(command).decode())
-        except Exception as e:
-            logger.error("Collector failed with:", e)
+        except Exception:
+            logger.error("Collector failed with:", exc_info=True)
             return False
 
     def _has_valid_docker_service(self):

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -1,3 +1,5 @@
+import glob
+import hashlib
 import http.client
 import json
 import logging
@@ -6,8 +8,6 @@ import shutil
 import subprocess
 import tempfile
 import uuid
-import hashlib
-import glob
 from functools import cached_property
 
 import jedi
@@ -210,25 +210,31 @@ class DjangoTemplateLanguageServer(LanguageServer):
             logger.debug(f"Found cachefile: {self.cache}")
             with open(self.cache, "r") as f:
                 django_data = json.load(f)
-            
+
             current_hash = self._get_cache_file_hash(django_data)
             if django_data.get("_hash", None) == current_hash:
                 logger.info(f"Loaded collected data from cachefile: {self.cache}")
                 return django_data
             else:
-                logger.debug(f"Cachefile hash does not match {current_hash} != {django_data.get('_hash', None)}")
+                logger.debug(
+                    f"Cachefile hash does not match {current_hash} != {django_data.get('_hash', None)}"
+                )
 
         return None
 
     def _store_django_data_to_cache(self, django_data):
-        django_data['_hash'] = self._get_cache_file_hash(django_data)
+        django_data["_hash"] = self._get_cache_file_hash(django_data)
 
         with open(self.cache, "w") as f:
             json.dump(django_data, f)
             logger.info(f"Wrote collected data to cachefile: {self.cache}")
 
     def _get_cache_file_hash(self, django_data):
-        files = set(f for p in django_data['file_watcher_globs'] for f in glob.glob(p, recursive=True))
+        files = set(
+            f
+            for p in django_data["file_watcher_globs"]
+            for f in glob.glob(p, recursive=True)
+        )
 
         sha256 = hashlib.sha256()
         for f in sorted(files):

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -159,8 +159,9 @@ class DjangoTemplateLanguageServer(LanguageServer):
             path=self.project_src_path, environment_path=self.project_env_path
         )
 
+        loaded_from_cache = False
         if self.cache and (django_data := self._get_django_data_from_cache()):
-            pass
+            loaded_from_cache = True
         elif self.project_env_path:
             django_data = self._get_django_data_from_python_path(
                 os.path.join(self.project_env_path, "bin", "python")
@@ -201,7 +202,7 @@ class DjangoTemplateLanguageServer(LanguageServer):
             self.current_file_watcher_globs = self.workspace_index.file_watcher_globs
             self.set_file_watcher_capability()
 
-        if self.cache:
+        if self.cache and not loaded_from_cache:
             self._store_django_data_to_cache(django_data)
 
     def _get_django_data_from_cache(self):

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -256,13 +256,9 @@ class DjangoTemplateLanguageServer(LanguageServer):
         return h.hexdigest()
 
     def _get_cache_location(self):
-        if self.cache is True:
-            h = hashlib.md5()
-            if self.workspace.root_path:
-                h.update(self.workspace.root_path.encode("utf-8"))
-            return os.path.join(
-                tempfile.gettempdir(), f"djlsp-data-{h.hexdigest()}.json"
-            )
+        if self.cache is True and self.workspace.root_path:
+            prefix = hashlib.md5(self.workspace.root_path.encode("utf-8")).hexdigest()
+            return os.path.join(tempfile.gettempdir(), f"djlsp-data-{prefix}.json")
         return self.cache
 
     def _get_django_data_from_python_path(self, python_path):


### PR DESCRIPTION
This PR adds (optional) caching to the LSP that caches the collected data if no files from the watch patterns have been changed to make faster LSP startups possible.

I have a few design considerations remaining, please let me know your opinion on them:
1. do you feel like use caching should be the default?
2. do you think we should check the file contents rather than the last modification date to calculate the hash? This takes a bit longer and adds a lot of disk I/O. On my machine checking the modification date (with 25 libs, 761 templates, 785 static files, 739 urls) takes about 0.04s and with contents about 0.5s.
