### PR TITLE
use local extends block detection for available block detections

### DIFF
--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -208,10 +208,11 @@ class TemplateParser:
         prefix = match.group(1).strip()
         logger.debug(f"Find block matches for: {prefix}")
         block_names = []
-        if "/templates/" in self.document.path:
-            template_name = self.document.path.split("/templates/", 1)[1]
-            if template := self.workspace_index.templates.get(template_name):
-                block_names = self._recursive_block_names(template.extends)
+        re_extends = re.compile(r""".*{% ?extends ['"](.*)['"] ?%}.*""")
+        for line in self.document.lines:
+            if matches := re_extends.match(line):
+                logger.debug(f"Finding available block names for {matches.group(1)}")
+                block_names = self._recursive_block_names(matches.group(1))
 
         used_block_names = []
         re_block = re.compile(r"{% *block ([\w]*) *%}")

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -209,10 +209,9 @@ class TemplateParser:
         logger.debug(f"Find block matches for: {prefix}")
         block_names = []
         re_extends = re.compile(r""".*{% ?extends ['"](.*)['"] ?%}.*""")
-        for line in self.document.lines:
-            if matches := re_extends.match(line):
-                logger.debug(f"Finding available block names for {matches.group(1)}")
-                block_names = self._recursive_block_names(matches.group(1))
+        if m := re_extends.search(self.document.source):
+            logger.debug(f"Finding available block names for {m.group(1)}")
+            block_names = self._recursive_block_names(m.group(1))
 
         used_block_names = []
         re_block = re.compile(r"{% *block ([\w]*) *%}")


### PR DESCRIPTION
Not sure why this was relying on the saved and collected version of the template. I do not really see an advantage here, please let me know if there is any. Doing it this way, makes this usable with templates that dont exist on the file system andtherefore have not been collected with the collector. Also this should work when the extends was changed only in memory and not saved to the file.