### PR TITLE
Basic parsing of more complex variable types

### DIFF
--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -139,6 +139,7 @@ class TemplateParser:
                 script_lines.append(f"{variable} = None")
 
         # Add user code
+        # django uses abc.0 for list index lookup, replace those with abc[0]
         script_lines.append(re.sub(r"(.*?)\.(\d+)", r"\1[\2]", code))
 
         logger.debug(f"===\n{'\n'.join(script_lines)}\n===")

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -190,7 +190,7 @@ class TemplateParser:
                 self.get_type_comment_complations,
             ),
             (
-                re.compile(r'.*({{|{% \w+ ).*?([\w\d_\.\[\]"]*)$'),
+                re.compile(r".*({{|{% \w+ ).*?([\w\d_\.]*)$"),
                 self.get_context_completions,
             ),
         ]
@@ -396,7 +396,7 @@ class TemplateParser:
             type_sort = {"statement": "1", "property": "2"}.get(comp.type, "9")
             return f"{type_sort}-{comp.name}".lower()
 
-        if "." in prefix or "[" in prefix:
+        if "." in prefix:
             # Find . completions with Jedi
             return [
                 CompletionItem(
@@ -428,7 +428,7 @@ class TemplateParser:
             (re.compile(r"^.*({%|{{) ?[\w \.\|]*\|(\w*)$"), self.get_filter_hover),
             (re.compile(r"^.*{% ?(\w*)$"), self.get_tag_hover),
             (
-                re.compile(r'.*({{|{% \w+ ).*?([\w\d_\.\[\]"]*)$'),
+                re.compile(r".*({{|{% \w+ ).*?([\w\d_\.]*)$"),
                 self.get_context_hover,
             ),
         ]
@@ -471,7 +471,7 @@ class TemplateParser:
         context_name = self._get_full_hover_name(line, character, match.group(2))
         logger.debug(f"Find context hover for: {context_name}")
 
-        if "." in context_name or "[" in context_name:
+        if "." in context_name:
             hlp = self.create_jedi_script(context_name).help()
             symbol_name = hlp[0].name if hlp else None
         else:

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -140,7 +140,7 @@ class TemplateParser:
 
         # Add user code
         # django uses abc.0 for list index lookup, replace those with abc[0]
-        script_lines.append(re.sub(r"(.*?)\.(\d+)", r"\1[\2]", code))
+        script_lines.append(re.sub(r"\.(\d+)", r"[\1]", code))
 
         logger.debug(f"===\n{'\n'.join(script_lines)}\n===")
 

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -1,6 +1,6 @@
+import hashlib
 import logging
 import re
-import hashlib
 from functools import cached_property
 from re import Match
 from textwrap import dedent
@@ -125,8 +125,12 @@ class TemplateParser:
                         continue
 
                     # create import alias to allow variable to have same name as module
-                    import_alias = "__" + hashlib.md5(variable_import.encode()).hexdigest()
-                    variable_type_aliased = variable_type_aliased.replace(variable_import, import_alias)
+                    import_alias = (
+                        "__" + hashlib.md5(variable_import.encode()).hexdigest()
+                    )
+                    variable_type_aliased = variable_type_aliased.replace(
+                        variable_import, import_alias
+                    )
                     script_lines.append(f"import {variable_import} as {import_alias}")
 
                 script_lines.append(f"{variable}: {variable_type_aliased}")

--- a/djlsp/parser.py
+++ b/djlsp/parser.py
@@ -118,7 +118,8 @@ class TemplateParser:
         for variable, variable_type in self.context.items():
             if variable_type:
                 variable_type_aliased = variable_type
-                # allow to use more complex types by splitting them into segments and import separatly
+                # allow to use more complex types by splitting them into segments
+                # and try to import them separatly
                 for imp in set(filter(None, re.split(r"\[|\]| |,", variable_type))):
                     variable_import = ".".join(imp.split(".")[:-1])
                     if variable_import == "":

--- a/djlsp/server.py
+++ b/djlsp/server.py
@@ -255,7 +255,7 @@ class DjangoTemplateLanguageServer(LanguageServer):
             patterns = list(
                 [
                     os.path.join(self.project_src_path, pattern)
-                    in django_data.get("file_watcher_globs", [])
+                    for pattern in django_data.get("file_watcher_globs", [])
                 ]
             )
 
@@ -268,7 +268,7 @@ class DjangoTemplateLanguageServer(LanguageServer):
 
         files_hash = hashlib.blake2b(digest_size=16)
         for file_path in sorted(files):
-            if "__pycache__" not in full_path and os.path.isfile(file_path):
+            if "__pycache__" not in file_path and os.path.isfile(file_path):
                 files_hash.update(f"{os.stat(file_path).st_mtime}".encode())
 
         logger.debug(f"Caculating cache hash took {time.time() - start_time:.4f}s")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -186,6 +186,23 @@ def test_completion_context_based_type_hint_comment():
     assert any(item.label == "capitalize" for item in parser.completions(1, 10))
 
 
+def test_completion_context_with_same_symbol_name():
+    parser = create_parser("{# type jedi: jedi.Script #}\n{{ jedi.com")
+    assert any(item.label == "complete" for item in parser.completions(1, 10))
+
+
+@pytest.mark.parametrize(
+    "typ,completion,results",
+    [
+        ("abc: list[str]", "{{ abc.0.", "capitalize"),
+        ("abc: list[jedi.Script] | dict[str, jedi.Script]", "{{ abc.0.", "complete"),
+    ],
+)
+def test_completion_context_advanced(typ, completion, results):
+    parser = create_parser("{# type " + typ + " #}\n" + completion)
+    assert any(item.label == results for item in parser.completions(1, len(completion)))
+
+
 ###################################################################################
 # Hovers
 ###################################################################################


### PR DESCRIPTION
This PR adds basic support for autocompletion and hover of more advanced types described in #95 point 1. (For loop support is still missing). 

```django
{# type order: list[order.models.PurchaseOrder] #}
{{ order.0.pk }}
```

Additionally it fixes a bug with variables that have the same name as the import. Previously they were not autocompleted:

```django
{# type order: order.models.PurchaseOrder #}
{{ order.
```

Please let me know what you think, and I'll add some basic tests covering the more complex autocompletions.

(And thanks for the additions with ignoring the pychache folders. Seems like there were some small typos, I just fixed those too to make it run again.)