### PR TITLE
Use correct django_settings_module config name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Project settings `.helix/languages.toml`:
 
 ```toml
 [language-server.djlsp.config]
-django_settings_modules="<your.settings.module>"
+django_settings_module="<your.settings.module>"
 ```
 
 ### Neovim

--- a/tests/django_test/.helix/languages.toml
+++ b/tests/django_test/.helix/languages.toml
@@ -3,7 +3,7 @@ command = "djlsp"
 args = ["--enable-log", "--cache"]
 
 [language-server.djlsp.config]
-django_settings_modules="django_test.settings"
+django_settings_module="django_test.settings"
 
 [[language]]
 name = "html"


### PR DESCRIPTION
I think there's a typo in the Helix configuration examples and the test config: there's no configuration directive for the plural of the Django settings module.