### PR TITLE
Fix invalid path on Windows for Vscode extenstion

### DIFF
--- a/vscode/client/src/extension.ts
+++ b/vscode/client/src/extension.ts
@@ -58,7 +58,7 @@ export function activate(context: ExtensionContext) {
 		throw new Error('No workspace folder is open');
 	}
 	const workspaceFolder = workspaceFolders[0];
-	const workspaceFolderPath = workspaceFolder.uri.path;
+	const workspaceFolderPath = workspaceFolder.uri.fsPath;
 
 	const serverOptions = () => {
 		const djlspProcess = spawn(djlspPath, djlspArgs, {


### PR DESCRIPTION
Docs about fspath: https://code.visualstudio.com/api/references/vscode-api#Uri

Resolves #116 